### PR TITLE
🚑 Fix simulator not serving all the clients

### DIFF
--- a/src/core/models/Server.ts
+++ b/src/core/models/Server.ts
@@ -1,49 +1,49 @@
-import type { Random } from "../../utils/random";
-import type { Distribution } from "../distributions/Distribution";
-import type { Client } from "./Client";
+import type { Random } from '../../utils/random'
+import type { Distribution } from '../distributions/Distribution'
+import type { Client } from './Client'
 
 export class Server {
   constructor(private servingRate: Distribution, private random: Random) {}
 
-  private timeRemainingUntilFree: number = -1;
-  private clientBeingServed?: Client;
-  private _onClientServed: (client: Client) => void = () => {};
+  private timeRemainingUntilFree: number = -1
+  private clientBeingServed?: Client
+  private _onClientServed: (client: Client) => void = () => {}
 
   set onClientServed(onClientServed: (client: Client) => void) {
-    this._onClientServed = onClientServed;
+    this._onClientServed = onClientServed
   }
 
   get isBusy(): boolean {
-    return this.timeRemainingUntilFree > 0;
+    return this.timeRemainingUntilFree > 0
   }
 
   get timeRemaining(): number {
-    return this.timeRemainingUntilFree;
+    return this.timeRemainingUntilFree
   }
 
   serve(client: Client) {
-    this.clientBeingServed = client;
-    this.timeRemainingUntilFree = Math.round(
-      this.servingRate.getVariable(this.random.get())
-    );
+    this.clientBeingServed = client
+    while (this.timeRemainingUntilFree <= 0) {
+      this.timeRemainingUntilFree = Math.round(this.servingRate.getVariable(this.random.get()))
+    }
   }
 
   tick(): void {
     if (this.timeRemainingUntilFree > 0) {
-      this.timeRemainingUntilFree--;
+      this.timeRemainingUntilFree--
     }
   }
 
   notifyIfFinished(): void {
     if (this.timeRemainingUntilFree === 0) {
-      this.notifyStation();
+      this.notifyStation()
     }
   }
 
   notifyStation() {
     if (this.clientBeingServed) {
-      this._onClientServed(this.clientBeingServed);
-      this.clientBeingServed = undefined;
+      this._onClientServed(this.clientBeingServed)
+      this.clientBeingServed = undefined
     }
   }
 }

--- a/src/core/models/Simulation.ts
+++ b/src/core/models/Simulation.ts
@@ -29,7 +29,10 @@ export class Simulation implements Mediator {
     const arrivingClients = this.arrivingClients
 
     while (arrivingClients > this.clientsServed) {
-      const clientsArrived = this.getClientsArrived()
+      const clientsArrived = this.getArrivingClients()
+      if (clientsArrived === 2) {
+        console.log('2 clients arrived')
+      }
       const clients: Client[] = Array.from({ length: clientsArrived }, () => this.createClient())
       this.enqueueClient(...clients)
       this.tick()
@@ -77,8 +80,8 @@ export class Simulation implements Mediator {
     return longestQueue
   }
 
-  getClientsArrived() {
-    const clientsArrived = this.arrivals[this._time]
+  getArrivingClients() {
+    const clientsArrived = this.arrivals[this._time] ?? 0
     this._clientsInSystem += clientsArrived
     return clientsArrived
   }

--- a/src/core/models/__tests__/simulation.test.ts
+++ b/src/core/models/__tests__/simulation.test.ts
@@ -1,77 +1,73 @@
-import { describe, expect, it, vi } from "vitest";
-import { SimulationBuilder } from "../Simulation";
-import { Station } from "../Station";
-import { ArrivalIterator } from "../ArrivalIterator";
-import { Poisson } from "../../distributions/poisson";
-import { Random } from "../../../utils/random";
-import { Server } from "../Server";
+import { describe, expect, it, vi } from 'vitest'
+import { SimulationBuilder } from '../Simulation'
+import { Station } from '../Station'
+import { ArrivalIterator } from '../ArrivalIterator'
+import { Poisson } from '../../distributions/poisson'
+import { Random } from '../../../utils/random'
+import { Server } from '../Server'
+import { Exponential } from '@/core/distributions/exponential'
 
-it("serves every client on the simulation", () => {
-  const arrivalIterator = new ArrivalIterator(
-    new Poisson(0.333),
-    new Random(2)
-  );
-  vi.spyOn(arrivalIterator, "getArrivals").mockReturnValue([1, 1, 1, 1]);
-
-  const distribution = new Poisson(0.5);
-  vi.spyOn(distribution, "getVariable").mockReturnValue(1);
-
-  const simulation = new SimulationBuilder()
-    .setStations([new Station(new Server(distribution, new Random(1)))])
-    .setArrivalIterator(arrivalIterator)
-    .setTimeStop(4)
-    .build();
-
-  simulation.run();
-
-  expect(simulation.clientsServed).toBe(4);
-});
-
-describe("Time duration tests", () => {
-  const arrivalIterator = new ArrivalIterator(
-    new Poisson(0.333),
-    new Random(2)
-  );
-  vi.spyOn(arrivalIterator, "getArrivals").mockReturnValue([1, 1, 1, 1]);
-
-  it("has a total time of 8", () => {
-    const distribution = new Poisson(0.5);
-    vi.spyOn(distribution, "getVariable").mockReturnValue(2);
+describe('Served client tests', () => {
+  it('serves every client on the simulation', () => {
+    const arrivalIterator = new ArrivalIterator(new Poisson(0.333), new Random(2))
+    vi.spyOn(arrivalIterator, 'getArrivals').mockReturnValue([1, 1, 1, 1])
+    const distribution = new Poisson(0.5)
+    vi.spyOn(distribution, 'getVariable').mockReturnValue(1)
 
     const simulation = new SimulationBuilder()
       .setStations([new Station(new Server(distribution, new Random(1)))])
       .setArrivalIterator(arrivalIterator)
       .setTimeStop(4)
-      .build();
+      .build()
 
-    simulation.run();
+    simulation.run()
 
-    expect(simulation.time).toBe(9);
-  });
+    expect(simulation.clientsServed).toBe(4)
+  })
+})
 
-  it("has a total time of 5 with 2 servers", () => {
-    const distribution = new Poisson(0.5);
-    vi.spyOn(distribution, "getVariable").mockReturnValue(2);
+describe('Time duration tests', () => {
+  const arrivalIterator = new ArrivalIterator(new Poisson(0.333), new Random(2))
+  vi.spyOn(arrivalIterator, 'getArrivals').mockReturnValue([1, 1, 1, 1])
+
+  it('has a total time of 8', () => {
+    const distribution = new Poisson(0.5)
+    vi.spyOn(distribution, 'getVariable').mockReturnValue(2)
+
+    const simulation = new SimulationBuilder()
+      .setStations([new Station(new Server(distribution, new Random(1)))])
+      .setArrivalIterator(arrivalIterator)
+      .setTimeStop(4)
+      .build()
+
+    simulation.run()
+
+    expect(simulation.time).toBe(9)
+  })
+
+  it('has a total time of 5 with 2 servers', () => {
+    const distribution = new Poisson(0.5)
+    vi.spyOn(distribution, 'getVariable').mockReturnValue(2)
 
     const simulation = new SimulationBuilder()
       .setStations([
         new Station(
           new Server(distribution, new Random(1)),
           new Server(distribution, new Random(1))
-        ),
+        )
       ])
       .setArrivalIterator(arrivalIterator)
       .setTimeStop(4)
-      .build();
+      .build()
 
-    simulation.run();
+    simulation.run()
 
-    expect(simulation.time).toBe(6);
-  });
+    expect(simulation.time).toBe(6)
+  })
 
-  it("has a total time of 8 with 3 servers and serving time of 4", () => {
-    const distribution = new Poisson(0.5);
-    vi.spyOn(distribution, "getVariable").mockReturnValue(4);
+  it('has a total time of 8 with 3 servers and serving time of 4', () => {
+    const distribution = new Poisson(0.5)
+    vi.spyOn(distribution, 'getVariable').mockReturnValue(4)
 
     const simulation = new SimulationBuilder()
       .setStations([
@@ -79,73 +75,67 @@ describe("Time duration tests", () => {
           new Server(distribution, new Random(1)),
           new Server(distribution, new Random(1)),
           new Server(distribution, new Random(1))
-        ),
+        )
       ])
       .setArrivalIterator(arrivalIterator)
       .setTimeStop(4)
-      .build();
+      .build()
 
-    simulation.run();
+    simulation.run()
 
-    expect(simulation.time).toBe(9);
-  });
+    expect(simulation.time).toBe(9)
+  })
 
-  it("has a total time of 14", () => {
-    const arrivalIterator = new ArrivalIterator(
-      new Poisson(0.333),
-      new Random(2)
-    );
-    vi.spyOn(arrivalIterator, "getArrivals").mockReturnValue([1, 2, 1, 3]);
+  it('has a total time of 14', () => {
+    const arrivalIterator = new ArrivalIterator(new Poisson(0.333), new Random(2))
+    vi.spyOn(arrivalIterator, 'getArrivals').mockReturnValue([1, 2, 1, 3])
 
-    const distribution = new Poisson(0.5);
-    vi.spyOn(distribution, "getVariable").mockReturnValue(2);
+    const distribution = new Poisson(0.5)
+    vi.spyOn(distribution, 'getVariable').mockReturnValue(2)
 
     const simulation = new SimulationBuilder()
       .setStations([new Station(new Server(distribution, new Random(1)))])
       .setArrivalIterator(arrivalIterator)
       .setTimeStop(4)
-      .build();
+      .build()
 
-    simulation.run();
+    simulation.run()
 
-    expect(simulation.time).toBe(15);
-  });
-});
+    expect(simulation.time).toBe(15)
+  })
+})
 
-describe("Multiple stations tests", () => {
-  const arrivalIterator = new ArrivalIterator(
-    new Poisson(0.333),
-    new Random(2)
-  );
-  vi.spyOn(arrivalIterator, "getArrivals").mockReturnValue([1, 1, 1, 1]);
+describe('Multiple stations tests', () => {
+  const arrivalIterator = new ArrivalIterator(new Poisson(0.333), new Random(2))
+  vi.spyOn(arrivalIterator, 'getArrivals').mockReturnValue([1, 1, 1, 1])
 
-  it("has a total time of 8 with 2 stations", () => {
-    const distribution1 = new Poisson(0.5);
-    vi.spyOn(distribution1, "getVariable").mockReturnValue(2);
+  it('has a total time of 8 with 2 stations', () => {
+    const distribution1 = new Poisson(0.5)
+    vi.spyOn(distribution1, 'getVariable').mockReturnValue(2)
 
-    const distribution2 = new Poisson(0.5);
-    vi.spyOn(distribution2, "getVariable").mockReturnValue(2);
+    const distribution2 = new Poisson(0.5)
+    vi.spyOn(distribution2, 'getVariable').mockReturnValue(2)
 
     const simulation = new SimulationBuilder()
       .setStations([
         new Station(new Server(distribution1, new Random(1))),
-        new Station(new Server(distribution2, new Random(1))),
+        new Station(new Server(distribution2, new Random(1)))
       ])
       .setArrivalIterator(arrivalIterator)
       .setTimeStop(4)
-      .build();
+      .build()
 
-    simulation.run();
+    simulation.run()
 
-    expect(simulation.time).toBe(11);
-  });
+    expect(simulation.time).toBe(11)
+  })
 
-  it("has a total time of 9 with 2 stations with 2 servers", () => {
-    const distribution1 = new Poisson(0.5);
-    vi.spyOn(distribution1, "getVariable").mockReturnValue(2);
+  it('has a total time of 9 with 2 stations with 2 servers', () => {
+    const distribution1 = new Poisson(0.5)
+    vi.spyOn(distribution1, 'getVariable').mockReturnValue(2)
 
-    const distribution2 = new Poisson(0.5);
-    vi.spyOn(distribution2, "getVariable").mockReturnValue(2);
+    const distribution2 = new Poisson(0.5)
+    vi.spyOn(distribution2, 'getVariable').mockReturnValue(2)
 
     const simulation = new SimulationBuilder()
       .setStations([
@@ -156,50 +146,47 @@ describe("Multiple stations tests", () => {
         new Station(
           new Server(distribution2, new Random(1)),
           new Server(distribution2, new Random(1))
-        ),
+        )
       ])
       .setArrivalIterator(arrivalIterator)
       .setTimeStop(4)
-      .build();
+      .build()
 
-    simulation.run();
+    simulation.run()
 
-    expect(simulation.time).toBe(8);
-  });
-});
+    expect(simulation.time).toBe(8)
+  })
+})
 
-describe("Longest queue tests", () => {
-  const arrivalIterator = new ArrivalIterator(
-    new Poisson(0.333),
-    new Random(2)
-  );
-  vi.spyOn(arrivalIterator, "getArrivals").mockReturnValue([1, 1, 1, 1]);
+describe('Longest queue tests', () => {
+  const arrivalIterator = new ArrivalIterator(new Poisson(0.333), new Random(2))
+  vi.spyOn(arrivalIterator, 'getArrivals').mockReturnValue([1, 1, 1, 1])
 
-  it("the first station has the longest queue with value 2", () => {
-    const distribution1 = new Poisson(0.5);
-    vi.spyOn(distribution1, "getVariable").mockReturnValue(2);
+  it('the first station has the longest queue with value 2', () => {
+    const distribution1 = new Poisson(0.5)
+    vi.spyOn(distribution1, 'getVariable').mockReturnValue(2)
 
-    const distribution2 = new Poisson(0.5);
-    vi.spyOn(distribution2, "getVariable").mockReturnValue(2);
+    const distribution2 = new Poisson(0.5)
+    vi.spyOn(distribution2, 'getVariable').mockReturnValue(2)
 
     const simulation = new SimulationBuilder()
       .setStations([
         new Station(new Server(distribution1, new Random(1))),
-        new Station(new Server(distribution2, new Random(1))),
+        new Station(new Server(distribution2, new Random(1)))
       ])
       .setArrivalIterator(arrivalIterator)
       .setTimeStop(4)
-      .build();
+      .build()
 
-    const results = simulation.run();
+    const results = simulation.run()
 
-    expect(results.longestQueue.station[0]).toBe(0);
-    expect(results.longestQueue.length).toBe(2);
-  });
+    expect(results.longestQueue.station[0]).toBe(0)
+    expect(results.longestQueue.length).toBe(2)
+  })
 
-  it("the first station has the longest queue with length 1", () => {
-    const distribution = new Poisson(0.5);
-    vi.spyOn(distribution, "getVariable").mockReturnValue(4);
+  it('the first station has the longest queue with length 1', () => {
+    const distribution = new Poisson(0.5)
+    vi.spyOn(distribution, 'getVariable').mockReturnValue(4)
 
     const simulation = new SimulationBuilder()
       .setStations([
@@ -207,60 +194,60 @@ describe("Longest queue tests", () => {
           new Server(distribution, new Random(1)),
           new Server(distribution, new Random(1)),
           new Server(distribution, new Random(1))
-        ),
+        )
       ])
       .setArrivalIterator(arrivalIterator)
       .setTimeStop(4)
-      .build();
+      .build()
 
-    const results = simulation.run();
+    const results = simulation.run()
 
-    expect(results.longestQueue.station[0]).toBe(0);
-    expect(results.longestQueue.length).toBe(1);
-  });
+    expect(results.longestQueue.station[0]).toBe(0)
+    expect(results.longestQueue.length).toBe(1)
+  })
 
-  it("the second station has the longest queue with value 3", () => {
-    const distribution1 = new Poisson(0.5);
-    vi.spyOn(distribution1, "getVariable").mockReturnValue(2);
+  it('the second station has the longest queue with value 3', () => {
+    const distribution1 = new Poisson(0.5)
+    vi.spyOn(distribution1, 'getVariable').mockReturnValue(2)
 
-    const distribution2 = new Poisson(0.5);
-    vi.spyOn(distribution2, "getVariable").mockReturnValue(8);
+    const distribution2 = new Poisson(0.5)
+    vi.spyOn(distribution2, 'getVariable').mockReturnValue(8)
 
     const simulation = new SimulationBuilder()
       .setStations([
         new Station(new Server(distribution1, new Random(1))),
-        new Station(new Server(distribution2, new Random(1))),
+        new Station(new Server(distribution2, new Random(1)))
       ])
       .setArrivalIterator(arrivalIterator)
       .setTimeStop(4)
-      .build();
+      .build()
 
-    const results = simulation.run();
+    const results = simulation.run()
 
-    expect(results.longestQueue.station[0]).toBe(1);
-    expect(results.longestQueue.length).toBe(3);
-  });
+    expect(results.longestQueue.station[0]).toBe(1)
+    expect(results.longestQueue.length).toBe(3)
+  })
 
-  it("both stations have the same longest queue", () => {
-    const distribution1 = new Poisson(0.5);
-    vi.spyOn(distribution1, "getVariable").mockReturnValue(2);
+  it('both stations have the same longest queue', () => {
+    const distribution1 = new Poisson(0.5)
+    vi.spyOn(distribution1, 'getVariable').mockReturnValue(2)
 
-    const distribution2 = new Poisson(0.5);
-    vi.spyOn(distribution2, "getVariable").mockReturnValue(5);
+    const distribution2 = new Poisson(0.5)
+    vi.spyOn(distribution2, 'getVariable').mockReturnValue(5)
 
     const simulation = new SimulationBuilder()
       .setStations([
         new Station(new Server(distribution1, new Random(1))),
-        new Station(new Server(distribution2, new Random(1))),
+        new Station(new Server(distribution2, new Random(1)))
       ])
       .setArrivalIterator(arrivalIterator)
       .setTimeStop(4)
-      .build();
+      .build()
 
-    const results = simulation.run();
+    const results = simulation.run()
 
-    expect(results.longestQueue.station[1]).toBe(1);
-    expect(results.longestQueue.station[0]).toBe(0);
-    expect(results.longestQueue.length).toBe(2);
-  });
-});
+    expect(results.longestQueue.station[1]).toBe(1)
+    expect(results.longestQueue.station[0]).toBe(0)
+    expect(results.longestQueue.length).toBe(2)
+  })
+})

--- a/src/pages/SetupPage.vue
+++ b/src/pages/SetupPage.vue
@@ -38,8 +38,8 @@
             <input v-model="options.simulationTime" id="simulation_duration" />
           </label>
           <label htmlFor="simulation_count">
-            Cantidad de simulaciones
-            <input v-model="options.simulationRuns" id="simulation_count" />
+            Semilla
+            <input v-model="options.seed" id="simulation_count" />
           </label>
         </div>
       </section>
@@ -99,7 +99,7 @@ const isEditModalOpen = ref(false)
 
 const options = ref<Options>({
   simulationTime: 0,
-  simulationRuns: 0
+  seed: 0
 })
 
 function clientNewStation() {

--- a/src/types/domain.d.ts
+++ b/src/types/domain.d.ts
@@ -11,5 +11,5 @@ type ServerData = {
 
 type Options = {
   simulationTime: number
-  simulationRuns: number
+  seed: number
 }

--- a/src/utils/simulation-runner.ts
+++ b/src/utils/simulation-runner.ts
@@ -24,13 +24,18 @@ export class SimulationRunner {
     const { arrival, stations, options } = this.data
     const builder = new SimulationBuilder()
 
-    builder.setArrivalIterator(new ArrivalIterator(this.getDistribution(arrival), new Random()))
+    builder.setArrivalIterator(
+      new ArrivalIterator(this.getDistribution(arrival), new Random(this.data.options.seed))
+    )
     builder.setTimeStop(options.simulationTime)
 
     builder.setStations(
       stations.map((station) => {
         const servers = station.servers.map((server) => {
-          return new Server(this.getDistribution(server.distribution), new Random())
+          return new Server(
+            this.getDistribution(server.distribution),
+            new Random(this.data.options.seed)
+          )
         })
 
         return new Station(...servers)
@@ -42,9 +47,7 @@ export class SimulationRunner {
 
   public get runs(): Promise<SimulationResults>[] {
     const results = []
-    for (let i = 0; i < this.data.options.simulationRuns; i++) {
-      results.push(this.simulationResultPromiseFactory(this.builder))
-    }
+    results.push(this.simulationResultPromiseFactory(this.builder))
     return results
   }
 


### PR DESCRIPTION
The problem was that sometimes the distribution on any server can yield numbers between 0 and 0.4, and that rounds it to 0.

It skips the client that it serving time is equal to 0

Commits: 
- ✨ Add seed field
- 🐛 Fix simulation not serving all the clients
